### PR TITLE
Replacing code with the TryToFix branch / Removed InputAckedFrame message

### DIFF
--- a/src/input/InputQueue.cs
+++ b/src/input/InputQueue.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace PleaseResync
@@ -6,29 +7,22 @@ namespace PleaseResync
     {
         public const int QueueSize = 128;
         private uint _frameDelay;
-        private uint _inputSize;
-        private uint _playerCount;
         private GameInput[] _inputs;
         private GameInput[] _lastPredictedInputs;
 
         public InputQueue(uint inputSize, uint playerCount, uint frameDelay = 0)
         {
-            _inputSize = inputSize;
             _frameDelay = frameDelay;
-            _playerCount = playerCount;
             _inputs = new GameInput[QueueSize];
             _lastPredictedInputs = new GameInput[QueueSize];
 
             for (int i = 0; i < _inputs.Length; i++)
             {
-                _inputs[i] = EmptyInput();
-                _lastPredictedInputs[i] = EmptyInput();
+                _inputs[i] = new GameInput(GameInput.NullFrame, inputSize, playerCount);
+                _lastPredictedInputs[i] = new GameInput(GameInput.NullFrame, inputSize, playerCount);
             }
         }
-        public GameInput EmptyInput()
-        {
-            return new GameInput(GameInput.NullFrame, _inputSize, _playerCount);
-        }
+
         public GameInput GetPredictedInput(int frame)
         {
             return _lastPredictedInputs[frame % QueueSize];
@@ -70,14 +64,11 @@ namespace PleaseResync
             return new GameInput(_inputs[frameOffset]);
         }
 
-        public void ResetPredictions()
+        public void ResetPrediction(int frame)
         {
             // when resetting the prediction we just make the frame a null frame.
-            // TODO MAKE A BETTER PREDDICTION SYSTEM.
-            for (int i = 0; i < QueueSize; i++)
-            {
-                _lastPredictedInputs[i].Frame = GameInput.NullFrame;
-            }
+            int frameOffset = frame % QueueSize;
+            _lastPredictedInputs[frameOffset].Frame = GameInput.NullFrame;
         }
 
         private int PreviousFrame(int offset) => (((offset) == 0) ? (QueueSize - 1) : ((offset) - 1));

--- a/src/session/Device.cs
+++ b/src/session/Device.cs
@@ -100,7 +100,7 @@ namespace PleaseResync
         {
             State = DeviceState.Running;
             var ev = new DeviceSyncedEvent { DeviceId = Id };
-            _session.AddSessionEvent(ev);
+            //_session.AddSessionEvent(ev);
         }
 
         #endregion
@@ -140,9 +140,10 @@ namespace PleaseResync
                     break;
                 case DeviceInputMessage inputMessage:
                     _session.AddRemoteInput(Id, inputMessage);
+                    LastAckedInputFrame = inputMessage.EndFrame; //Getting the acked frame from the input message
                     break;
                 case DeviceInputAckMessage inputAckMessage:
-                    UpdateAckedInputFrame(inputAckMessage);
+                    //UpdateAckedInputFrame(inputAckMessage); //Removed for now
                     break;
             }
         }

--- a/src/session/Session.cs
+++ b/src/session/Session.cs
@@ -84,10 +84,6 @@ namespace PleaseResync
         /// </summary>
         public abstract void Poll();
         /// <summary>
-        /// Returns a queue with all the events that happend since the last call to this function.
-        /// <summary>
-        public abstract Queue<SessionEvent> Events();
-        /// <summary>
         /// IsRunning returns true when all the Sessions are synchronized and ready to accept inputs.
         /// </summary>
         public abstract bool IsRunning();
@@ -97,9 +93,7 @@ namespace PleaseResync
         /// <param name="localInput">the local device input for the current frame</param>
         /// <returns>a list of actions to perform in order before calling AdvanceFrame again</returns>
         public abstract List<SessionAction> AdvanceFrame(byte[] localInput);
-
-        protected internal abstract uint SendMessageTo(uint deviceId, DeviceMessage message);
-        protected internal abstract void AddRemoteInput(uint deviceId, DeviceInputMessage message);
-        protected internal abstract void AddSessionEvent(SessionEvent ev);
+        internal protected abstract uint SendMessageTo(uint deviceId, DeviceMessage message);
+        internal protected abstract void AddRemoteInput(uint deviceId, DeviceInputMessage message);
     }
 }

--- a/src/synchronization/TimeSync.cs
+++ b/src/synchronization/TimeSync.cs
@@ -4,20 +4,22 @@ namespace PleaseResync
     {
         public const int InitialFrame = 0;
         public const int MaxRollbackFrames = 7;
+        public const int FrameAdvLimit = 4;
         public int SyncFrame;
         public int LocalFrame;
         public int RemoteFrame;
-        public int FrameAdvantage;
-
+        public int RemoteFrameAdvantage;
+        public int LocalFrameAdvantage;
         public TimeSync()
         {
             SyncFrame = InitialFrame;
             LocalFrame = InitialFrame;
             RemoteFrame = InitialFrame;
-            FrameAdvantage = InitialFrame;
+            RemoteFrameAdvantage = 0;
+            LocalFrameAdvantage = 0;
         }
 
-        public void UpdateTimeSync(Device[] devices)
+        public bool IsTimeSynced(Device[] devices)
         {
             int minRemoteFrame = int.MaxValue;
             int maxRemoteFrameAdvantage = int.MinValue;
@@ -40,18 +42,18 @@ namespace PleaseResync
             }
             // Set variables
             RemoteFrame = minRemoteFrame;
-            FrameAdvantage = maxRemoteFrameAdvantage;
+            RemoteFrameAdvantage = maxRemoteFrameAdvantage;
+            // How far the client is ahead of the last reported frame by the remote clients           
+            LocalFrameAdvantage = LocalFrame - RemoteFrame;
+            int frameAdvDiff = LocalFrameAdvantage - RemoteFrameAdvantage;
+            // Only allow the local client to get so far ahead of remote.
+            return LocalFrameAdvantage < MaxRollbackFrames && frameAdvDiff <= FrameAdvLimit ;
         }
 
         public bool ShouldRollback()
         {
             // No need to rollback if we don't have a frame after the previous sync frame to synchronize to.
             return LocalFrame > SyncFrame && RemoteFrame > SyncFrame;
-        }
-
-        public bool PredictionLimitReached()
-        {
-            return LocalFrame >= MaxRollbackFrames && FrameAdvantage >= MaxRollbackFrames;
         }
     }
 }


### PR DESCRIPTION
Apparently the changes in the TryToFix branch actualy worked
The weird issue is with the input messages... The InputAckedFrame message reaches the other peer too late and it breaks the simulation pace. I'm using the endFrame from the InputFrame message as the last acked frame for now.